### PR TITLE
feat(auth): Modify Kakao OAuth2 login modules & add logout

### DIFF
--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -25,6 +25,7 @@ ext {
 dependencies {
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-server'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/user-service/src/main/java/com/swidx/userservice/auth/AuthController.java
+++ b/user-service/src/main/java/com/swidx/userservice/auth/AuthController.java
@@ -2,10 +2,15 @@ package com.swidx.userservice.auth;
 
 import com.swidx.userservice.dto.KakaoUserDto;
 import com.swidx.userservice.dto.LoginResponseDto;
+import com.swidx.userservice.dto.ReissueResponseDto;
 import com.swidx.userservice.pojo.AccessToken;
 import com.swidx.userservice.service.LoginService;
+import com.swidx.userservice.service.ReissueService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @RestController
@@ -13,11 +18,29 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
     private final KakaoOAuth2UserService kakaoService;
     private final LoginService loginService;
+    private final ReissueService reissueService;
 
     @PostMapping("/kakao")
-    public LoginResponseDto kakaoLogin(@RequestBody AccessToken accessToken) {
+    public ResponseEntity<LoginResponseDto> kakaoLogin(@CookieValue(value = "refreshToken", defaultValue = "") String refreshToken, @RequestBody AccessToken accessToken) throws Exception {
+        boolean primary = Objects.equals(refreshToken, "");
         KakaoUserDto userinfo = kakaoService.getUserInfo(accessToken);
-        if (userinfo == null) return new LoginResponseDto("err", "", "", "", "");
-        return loginService.registerUser(userinfo);
+
+        if (userinfo == null) // 차후 수정하기
+            throw new Exception("\n*** AuthController: 카카오 서버로부터 사용자 정보를 가져오는데 실패했습니다. ***");
+
+        if (primary) // 최초 로그인
+            return loginService.registerUser(userinfo);
+        else // 다중 클라이언트 대응
+            return loginService.getPrimaryToken(userinfo, refreshToken);
+    }
+
+    @GetMapping("/reissue")
+    public ResponseEntity<ReissueResponseDto> reissueJWT(@CookieValue("refreshToken") String refreshToken) {
+        return reissueService.reissueJWT(refreshToken);
+    }
+
+    @DeleteMapping("/logout")
+    public ResponseEntity<Void> deleteToken(@CookieValue("refreshToken") String refreshToken) {
+        return loginService.deleteToken(refreshToken);
     }
 }

--- a/user-service/src/main/java/com/swidx/userservice/auth/SecurityConfig.java
+++ b/user-service/src/main/java/com/swidx/userservice/auth/SecurityConfig.java
@@ -1,0 +1,26 @@
+package com.swidx.userservice.auth;
+
+// WebSecurityConfigurerAdapter is deprecated
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .headers().frameOptions().disable()
+                .and()
+                .authorizeRequests()
+                .antMatchers("/user-service/auth/**").permitAll()
+                .anyRequest().authenticated();
+
+        return http.build();
+    }
+}

--- a/user-service/src/main/java/com/swidx/userservice/dto/LoginResponseDto.java
+++ b/user-service/src/main/java/com/swidx/userservice/dto/LoginResponseDto.java
@@ -10,5 +10,5 @@ public class LoginResponseDto {
     private String email;
     private String profileImageUrl;
     private String accessToken;
-    private String refreshToken;
+    private Long expirationTime;
 }

--- a/user-service/src/main/java/com/swidx/userservice/dto/ReissueResponseDto.java
+++ b/user-service/src/main/java/com/swidx/userservice/dto/ReissueResponseDto.java
@@ -1,0 +1,13 @@
+package com.swidx.userservice.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Date;
+
+@AllArgsConstructor
+@Getter
+public class ReissueResponseDto {
+    private String accessToken;
+    private Long expirationTime;
+}

--- a/user-service/src/main/java/com/swidx/userservice/redis/Token.java
+++ b/user-service/src/main/java/com/swidx/userservice/redis/Token.java
@@ -8,12 +8,15 @@ import org.springframework.data.redis.core.RedisHash;
 // import javax.persistence.Id;
 
 @Getter
-@RedisHash(value = "refreshToken", timeToLive = 10L) // 10L for testing
+@RedisHash(value = "refreshToken", timeToLive = 180L) // 180L == 180s for testing
 public class Token {
     @Id
     private String refreshToken;
 
-    public Token(String refreshToken) {
+    private String id;
+
+    public Token(String refreshToken, String id) {
         this.refreshToken = refreshToken;
+        this.id = id;
     }
 }

--- a/user-service/src/main/java/com/swidx/userservice/service/LoginService.java
+++ b/user-service/src/main/java/com/swidx/userservice/service/LoginService.java
@@ -51,7 +51,7 @@ public class LoginService {
         // 변동: mariadb 업데이트
         if (!name.equals(entity.getName()) || !profileImageUrl.equals(entity.getProfileImageUrl())) {
             System.out.println("\n*** LoginService: Update User ***");
-            entity.update(userinfo);
+            db.save(new User(userinfo));
         }
 
         LoginResponseDto loginbody = new LoginResponseDto(

--- a/user-service/src/main/java/com/swidx/userservice/service/LoginService.java
+++ b/user-service/src/main/java/com/swidx/userservice/service/LoginService.java
@@ -4,22 +4,31 @@ import com.swidx.userservice.domain.user.User;
 import com.swidx.userservice.domain.user.UserRepository;
 import com.swidx.userservice.dto.KakaoUserDto;
 import com.swidx.userservice.dto.LoginResponseDto;
+import com.swidx.userservice.dto.ReissueResponseDto;
 import com.swidx.userservice.redis.Token;
 import com.swidx.userservice.redis.TokenRedisRepository;
+import com.swidx.userservice.util.CookieUtil;
 import com.swidx.userservice.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 
 @RequiredArgsConstructor
 @Service
 public class LoginService {
     private final JwtUtil jwtUtil;
+    private final CookieUtil cookieUtil;
     private final TokenRedisRepository redis;
     private final UserRepository db;
     boolean firstRegister = false;
 
-    public LoginResponseDto registerUser(KakaoUserDto userinfo) {
+    public ResponseEntity<LoginResponseDto> registerUser(KakaoUserDto userinfo) {
         // jwt 발급
         String id = userinfo.getId();
         String name = userinfo.getName();
@@ -28,7 +37,7 @@ public class LoginService {
         String refreshToken = jwtUtil.generateRefreshToken(1000L * 60 * 60 * 6); // 6 hr
 
         // redis 등록
-        redis.save(new Token(refreshToken)); // String -> Token Entity
+        redis.save(new Token(refreshToken, id)); // String -> Token Entity
 
         // 신규: mariadb 등록
         User entity = db.findById(id).orElseGet( // orElse()는 empty 여부 관계 없이 인자 내 함수를 실행하므로 orElseGet() 사용
@@ -45,13 +54,67 @@ public class LoginService {
             entity.update(userinfo);
         }
 
-        return new LoginResponseDto(
+        LoginResponseDto loginbody = new LoginResponseDto(
                 name,
                 userinfo.getEmail(),
                 profileImageUrl,
                 accessToken,
-                refreshToken
+                jwtUtil.getTokenExpirationTime(accessToken)
         );
+
+        // 헤더에 들어감
+        Long refreshMaxAge = 60L * 60 * 6;
+        ResponseCookie loginCookie = cookieUtil.generateRefreshTokenCookie(refreshToken, refreshMaxAge);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, loginCookie.toString())
+                .body(loginbody);
+    }
+
+    public ResponseEntity<LoginResponseDto> getPrimaryToken(KakaoUserDto userinfo, String rt) {
+        System.out.println("\n*** LoginService: Secondary User Login ***");
+        String id = userinfo.getId();
+        String name = userinfo.getName();
+        String profileImageUrl = userinfo.getProfileImageUrl();
+        String accessToken = jwtUtil.generateAccessToken(id, 1000L * 60 * 30); // 30 min
+        Token refreshToken = redis.findById(rt).orElseThrow(
+                () -> new IllegalArgumentException("\n*** LoginService(Secondary): Invalid Refresh Token ***")
+        );
+
+        // mariadb에 등록된 사용자 정보 가져오기
+        User entity = db.findById(id).orElseThrow(
+                () -> new IllegalArgumentException("\n*** LoginService(Secondary): Invalid User ID ***")
+        );
+
+        // 변동: mariadb 업데이트
+        if (!name.equals(entity.getName()) || !profileImageUrl.equals(entity.getProfileImageUrl())) {
+            System.out.println("\n*** LoginService(Secondary): Update User ***");
+            db.save(new User(userinfo));
+        }
+
+        LoginResponseDto loginbody = new LoginResponseDto(
+                name,
+                userinfo.getEmail(),
+                profileImageUrl,
+                accessToken,
+                jwtUtil.getTokenExpirationTime(accessToken)
+        );
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(loginbody); // no header
+    }
+
+    public ResponseEntity<Void> deleteToken(String rt) {
+        Optional<Token> refreshToken = redis.findById(rt);
+        if (refreshToken.isPresent()) {
+            redis.deleteById(rt);
+        }
+
+        ResponseCookie logoutCookie = cookieUtil.expireRefreshTokenCookie();
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, logoutCookie.toString())
+                .body(null);
     }
 
     private User addUserdata(KakaoUserDto userinfo) {

--- a/user-service/src/main/java/com/swidx/userservice/service/ReissueService.java
+++ b/user-service/src/main/java/com/swidx/userservice/service/ReissueService.java
@@ -1,0 +1,51 @@
+package com.swidx.userservice.service;
+
+import com.swidx.userservice.dto.ReissueResponseDto;
+import com.swidx.userservice.redis.Token;
+import com.swidx.userservice.redis.TokenRedisRepository;
+import com.swidx.userservice.util.CookieUtil;
+import com.swidx.userservice.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ReissueService {
+    private final JwtUtil jwtUtil;
+    private final TokenRedisRepository redis;
+    private final CookieUtil cookieUtil;
+
+    public ResponseEntity<ReissueResponseDto> reissueJWT(String rt) {
+        Token refreshToken = redis.findById(rt).orElseThrow(
+                () -> new AccessDeniedException("\n*** ReissueService: Invalid Refresh Token ***")
+        );
+        String id = refreshToken.getId();
+
+        String newAccessToken = jwtUtil.generateAccessToken(id, 1000L * 60 * 30); // 30 min
+        String newRefreshToken = jwtUtil.generateRefreshToken(1000L * 60 * 60 * 6); // 6 hr
+
+        // redis 업데이트
+        redis.deleteById(rt); // invalidate previous token
+        redis.save(new Token(newRefreshToken, id)); // String -> Token Entity
+
+        ReissueResponseDto reissueBody = new ReissueResponseDto(
+                newAccessToken,
+                jwtUtil.getTokenExpirationTime(newAccessToken)
+        );
+
+        // 헤더에 들어감
+        // maxAge는 초단위이고, 카운트다운 같은 개념이므로 JWT exp time과 혼동하면 안됨
+        Long refreshMaxAge = 60L * 60 * 6;
+        ResponseCookie reissueCookie = cookieUtil.generateRefreshTokenCookie(newRefreshToken, refreshMaxAge);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .header(HttpHeaders.SET_COOKIE, reissueCookie.toString())
+                .body(reissueBody);
+    }
+
+}

--- a/user-service/src/main/java/com/swidx/userservice/util/CookieUtil.java
+++ b/user-service/src/main/java/com/swidx/userservice/util/CookieUtil.java
@@ -1,0 +1,28 @@
+package com.swidx.userservice.util;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    public ResponseCookie generateRefreshTokenCookie(String refreshToken, Long refreshMaxAge) {
+        return ResponseCookie.from("refreshToken", refreshToken)
+                .path("/")
+                .sameSite("Strict")
+                .httpOnly(true)
+                .secure(false) // 프로덕션(https)에선 반드시 true로 설정하기
+                .maxAge(refreshMaxAge)
+                .build();
+    }
+
+    public ResponseCookie expireRefreshTokenCookie() {
+        return ResponseCookie.from("refreshToken", "")
+                .path("/")
+                .sameSite("Strict")
+                .httpOnly(true)
+                .secure(false) // 프로덕션(https)에선 반드시 true로 설정하기
+                .maxAge(0)
+                .build();
+    }
+}

--- a/user-service/src/main/java/com/swidx/userservice/util/JwtUtil.java
+++ b/user-service/src/main/java/com/swidx/userservice/util/JwtUtil.java
@@ -52,6 +52,15 @@ public class JwtUtil {
         return claims.getSubject();
     }
 
+    // Identify token expiration date from the received token
+    public Long getTokenExpirationTime(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(JWT_SECRET)
+                .parseClaimsJws(token)
+                .getBody();
+        return claims.getExpiration().getTime();
+    }
+
     public boolean validateToken(String token) {
         try {
             Jwts.parser().setSigningKey(JWT_SECRET).parseClaimsJws(token);


### PR DESCRIPTION
- temporarily patch entity update bug
- modify login response specification
    - refresh token has been removed from response body, and will be set into cookie by a response header
- add `/reissue` api to maintain login status
- add `/logout` api

Closes #1, closes #10