### PR TITLE
feat: Add user like (include user PK fix)

### DIFF
--- a/user-service/src/main/java/com/swidx/userservice/auth/SecurityConfig.java
+++ b/user-service/src/main/java/com/swidx/userservice/auth/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
                 .headers().frameOptions().disable()
                 .and()
                 .authorizeRequests()
-                .antMatchers("/user-service/auth/**").permitAll()
+                .antMatchers("/user-service/auth/**","/user-service/user/**").permitAll()
                 .anyRequest().authenticated();
 
         return http.build();

--- a/user-service/src/main/java/com/swidx/userservice/controller/LikeController.java
+++ b/user-service/src/main/java/com/swidx/userservice/controller/LikeController.java
@@ -1,0 +1,56 @@
+package com.swidx.userservice.controller;
+
+import com.swidx.userservice.feign.client.FeignJwtValidationService;
+import com.swidx.userservice.service.LikeService;
+import com.swidx.userservice.util.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("user-service/user")
+public class LikeController {
+    private final JwtUtil jwtUtil;
+    // private final FeignJwtValidationService feignJwtValidationService;
+    private final LikeService likeService;
+
+    @GetMapping("/like/{place_id}")
+    public boolean checkUserLike(@RequestHeader("Authorization") String authorization,
+                                 @PathVariable("place_id") Long placeId) {
+        String accessToken = authorization.replace("Bearer ", "");
+
+        // if (!feignJwtValidationService.check(accessToken)) {
+        if (!jwtUtil.validateToken(accessToken)) {
+            throw new java.lang.RuntimeException("*** LikeController: JWT Check Fail ***");
+        }
+
+        String email = jwtUtil.getTokenOwner(accessToken);
+        return likeService.checkUserLike(email, placeId);
+    }
+
+    @PutMapping("/like/{place_id}")
+    public void addUserLike(@RequestHeader("Authorization") String authorization,
+                            @PathVariable("place_id") Long placeId) {
+        String accessToken = authorization.replace("Bearer ", "");
+
+        if (!jwtUtil.validateToken(accessToken)) {
+            throw new java.lang.RuntimeException("*** LikeController: JWT Check Fail ***");
+        }
+
+        String email = jwtUtil.getTokenOwner(accessToken);
+        likeService.addUserLike(email, placeId);
+    }
+
+    @DeleteMapping("/like/{place_id}")
+    public void deleteUserLike(@RequestHeader("Authorization") String authorization,
+                               @PathVariable("place_id") Long placeId) {
+        String accessToken = authorization.replace("Bearer ", "");
+
+        if (!jwtUtil.validateToken(accessToken)) {
+            throw new java.lang.RuntimeException("*** LikeController: JWT Check Fail ***");
+        }
+
+        String email = jwtUtil.getTokenOwner(accessToken);
+        likeService.deleteUserLike(email, placeId);
+    }
+}

--- a/user-service/src/main/java/com/swidx/userservice/domain/like/Like.java
+++ b/user-service/src/main/java/com/swidx/userservice/domain/like/Like.java
@@ -1,0 +1,23 @@
+package com.swidx.userservice.domain.like;
+
+import org.hibernate.annotations.GenericGenerator;
+
+import javax.persistence.*;
+import java.util.UUID;
+
+@Entity
+public class Like {
+    @Id
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID like_id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private Long place_id;
+
+    // WIP..
+}

--- a/user-service/src/main/java/com/swidx/userservice/domain/like/Like.java
+++ b/user-service/src/main/java/com/swidx/userservice/domain/like/Like.java
@@ -1,23 +1,28 @@
 package com.swidx.userservice.domain.like;
 
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
-
 import javax.persistence.*;
 import java.util.UUID;
 
+@NoArgsConstructor
+@Table(name = "user_like")
 @Entity
 public class Like {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "uuid2")
     @Column(columnDefinition = "BINARY(16)")
-    private UUID like_id;
+    private UUID likeId;
 
     @Column(nullable = false)
     private String email;
 
     @Column(nullable = false)
-    private Long place_id;
+    private Long placeId;
 
-    // WIP..
+    public Like(String email, Long placeId) {
+        this.email = email;
+        this.placeId = placeId;
+    }
 }

--- a/user-service/src/main/java/com/swidx/userservice/domain/like/LikeRepository.java
+++ b/user-service/src/main/java/com/swidx/userservice/domain/like/LikeRepository.java
@@ -2,7 +2,10 @@ package com.swidx.userservice.domain.like;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface LikeRepository extends JpaRepository<Like, UUID> {
+    Optional<Like> findByEmailAndPlaceId(String email, Long placeId); // WHERE .. AND ..
+    Optional<Like> deleteByEmailAndPlaceId(String email, Long placeId);
 }

--- a/user-service/src/main/java/com/swidx/userservice/domain/like/LikeRepository.java
+++ b/user-service/src/main/java/com/swidx/userservice/domain/like/LikeRepository.java
@@ -1,0 +1,8 @@
+package com.swidx.userservice.domain.like;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface LikeRepository extends JpaRepository<Like, UUID> {
+}

--- a/user-service/src/main/java/com/swidx/userservice/domain/user/User.java
+++ b/user-service/src/main/java/com/swidx/userservice/domain/user/User.java
@@ -13,13 +13,13 @@ import javax.persistence.Id;
 @Entity
 public class User {
     @Id
+    private String email;
+
+    @Column(nullable = false)
     private String id;
 
     @Column(nullable = false)
     private String name;
-
-    @Column(nullable = false)
-    private String email;
 
     @Column(nullable = false)
     private String profileImageUrl;

--- a/user-service/src/main/java/com/swidx/userservice/service/LikeService.java
+++ b/user-service/src/main/java/com/swidx/userservice/service/LikeService.java
@@ -1,0 +1,28 @@
+package com.swidx.userservice.service;
+
+import com.swidx.userservice.domain.like.Like;
+import com.swidx.userservice.domain.like.LikeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Service
+public class LikeService {
+    private final LikeRepository db;
+
+    public boolean checkUserLike(String email, Long placeId) {
+        Optional<Like> entity = db.findByEmailAndPlaceId(email, placeId);
+        return entity.isPresent();
+    }
+
+    public void addUserLike(String email, Long placeId) {
+        db.save(new Like(email, placeId));
+    }
+
+    @Transactional
+    public void deleteUserLike(String email, Long placeId) {
+        db.deleteByEmailAndPlaceId(email, placeId);
+    }
+}

--- a/user-service/src/main/java/com/swidx/userservice/util/JwtUtil.java
+++ b/user-service/src/main/java/com/swidx/userservice/util/JwtUtil.java
@@ -43,8 +43,8 @@ public class JwtUtil {
                 .compact();
     }
 
-    // Identify user id from the received token
-    public String getTokenOwnerId(String token) {
+    // Identify user email from the received token
+    public String getTokenOwner(String token) {
         Claims claims = Jwts.parser()
                 .setSigningKey(JWT_SECRET)
                 .parseClaimsJws(token)


### PR DESCRIPTION
- JWT access token 검증 로직 추가
- 찜(좋아요) 추가/확인/삭제 REST API 구현
- user 테이블의 PK를 id에서 email로 변경 (카카오계정의 id는 mutable해서 PK로 부적절함)